### PR TITLE
Try deserializing specific SagaData type

### DIFF
--- a/Rebus.AdoNet/AdoNetSagaPersister.cs
+++ b/Rebus.AdoNet/AdoNetSagaPersister.cs
@@ -422,6 +422,12 @@ namespace Rebus.AdoNet
 
 					try
 					{
+						return JsonConvert.DeserializeObject<TSagaData>(value, Settings);
+					}
+					catch { }
+
+					try
+					{
 						return (TSagaData)JsonConvert.DeserializeObject(value, Settings);
 					}
 					catch (Exception exception)


### PR DESCRIPTION
To support SagaData types serialized without the $type field, try to deserialize first using Newtonsoft's generic method indicating the specific SagaData type.