### PR TITLE
Bug obtaining wrong saga data when sagas shared index key id and index key value

### DIFF
--- a/Rebus.AdoNet/AdoNetSagaPersister.cs
+++ b/Rebus.AdoNet/AdoNetSagaPersister.cs
@@ -155,9 +155,17 @@ namespace Rebus.AdoNet
 							PrimaryKey = new[] { SAGAINDEX_ID_COLUMN, SAGAINDEX_KEY_COLUMN },
 							Indexes = new []
 							{
-								new AdoNetIndex() { Name = "ix_sagaindexes_id", Columns = new[] { SAGAINDEX_ID_COLUMN } },
-								new AdoNetIndex() { Name = "ix_sagaindexes_key_value", Columns = new[] { SAGAINDEX_KEY_COLUMN, SAGAINDEX_VALUE_COLUMN } },
-								new AdoNetIndex() { Name = "ix_sagaindexes_key_values", Columns = new[] { SAGAINDEX_KEY_COLUMN, SAGAINDEX_VALUES_COLUMN } }
+								new AdoNetIndex() { Name = $"ix_{sagaIndexTableName}_{SAGAINDEX_ID_COLUMN}", Columns = new[] { SAGAINDEX_ID_COLUMN } },
+								new AdoNetIndex()
+								{
+									Name = $"ix_{sagaIndexTableName}_{SAGAINDEX_KEY_COLUMN}_{SAGAINDEX_VALUE_COLUMN}",
+									Columns = new[] { SAGAINDEX_KEY_COLUMN, SAGAINDEX_VALUE_COLUMN }
+								},
+								new AdoNetIndex()
+								{
+									Name = $"ix_{sagaIndexTableName}_{SAGAINDEX_KEY_COLUMN}_{SAGAINDEX_VALUES_COLUMN}",
+									Columns = new[] { SAGAINDEX_KEY_COLUMN, SAGAINDEX_VALUES_COLUMN }
+								}
 							}
 						}
 					);

--- a/Rebus.AdoNet/Rebus.AdoNet.nuspec
+++ b/Rebus.AdoNet/Rebus.AdoNet.nuspec
@@ -14,6 +14,7 @@
 		<copyright>Copyright Evidencias Certificadas, S.L. 2015-2016</copyright>
 		<dependencies>
 			<dependency id="Rebus" version="[0.84.0,0.90)" />
+			<dependency id="Newtonsoft.Json" version="8.0.2" />
 		</dependencies>
 	</metadata>
 	<files>


### PR DESCRIPTION
This branch does several things:

- Added dependency for nuspec to require NewtonSoft.Json when using this nuget because its required to deserialize sagadata.
- Fixed index names for tables saga and saga-indexes.
- Fixed bug when finding sagadata not searching by id property. If there are two sagas with same saga-index key (property to be searched) and saga-index key (value to be searched), library was returning results even if it was sagadata from another saga type because saga_type wasn't included in the query that obtained saga data.