### PR TITLE
Modified AdoNetUnitOfWork's visibility from internal to public

### DIFF
--- a/Rebus.AdoNet/AdoNetUnitOfWork.cs
+++ b/Rebus.AdoNet/AdoNetUnitOfWork.cs
@@ -73,7 +73,7 @@ namespace Rebus.AdoNet
 			}
 		}
 		
-		public AdoNetUnitOfWorkScope GetScope()
+		public virtual AdoNetUnitOfWorkScope GetScope()
 		{
 			EnsureNotDisposed();
 			
@@ -91,7 +91,7 @@ namespace Rebus.AdoNet
 			return result;
 		}
 
-		public void Abort()
+		public virtual void Abort()
 		{
 			EnsureNotDisposed();
 			
@@ -103,7 +103,7 @@ namespace Rebus.AdoNet
 			_log.Debug("Rolled back transaction: {0}...", Transaction.GetHashCode());
 		}
 
-		public void Commit()
+		public virtual void Commit()
 		{
 			EnsureNotDisposed();
 			

--- a/Rebus.AdoNet/AdoNetUnitOfWork.cs
+++ b/Rebus.AdoNet/AdoNetUnitOfWork.cs
@@ -16,7 +16,7 @@ namespace Rebus.AdoNet
 		AdoNetUnitOfWorkScope GetScope();
 	}
 
-	internal class AdoNetUnitOfWork : IAdoNetUnitOfWork
+	public class AdoNetUnitOfWork : IAdoNetUnitOfWork
 	{
 		private static ILog _log;
 		private readonly AdoNetConnectionFactory _factory;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49149147/182364444-e6370482-538f-46c0-a1ba-3e530ac83be9.png)

The AdoNetUnitOfWork class, currently, is internal.. so anyone which is configuring rebus's sagas with a custom unit of work creator.. will get a NRE on this method as the "custom" uow cannot extend "easily" this class.

Btw, I'm just creating this PR to testing something.