### PR TITLE
Small fix to Persister's ShouldIndexValue

### DIFF
--- a/Rebus.AdoNet/AdoNetSagaPersister.cs
+++ b/Rebus.AdoNet/AdoNetSagaPersister.cs
@@ -204,6 +204,23 @@ saga type name.",
 		
 		#endregion
 
+		protected virtual bool ShouldIndexValue(KeyValuePair<string, object> pair)
+		{
+			if (IndexNullProperties)
+				return true;
+
+			if (string.IsNullOrWhiteSpace(pair.Key)) //< XXX: Could we reach this condition?
+				return false;
+
+			if (pair.Value == null) return false;
+			if (pair.Value is string) return true;
+			if (pair.Value is Guid uuid && uuid == default(Guid)) return false; //< Avoid empty guids..
+			if (pair.Value is DateTime date && date == default(DateTime)) return false; //< Avoid def datetimes..
+			if (pair.Value is IEnumerable e && !e.Cast<object>().Any()) return false;
+
+			return true;
+		}
+
 		protected string Serialize(ISagaData sagaData)
 		{
 			return JsonConvert.SerializeObject(sagaData, Formatting.Indented, Settings);

--- a/Rebus.AdoNet/AdoNetSagaPersisterAdvanced.cs
+++ b/Rebus.AdoNet/AdoNetSagaPersisterAdvanced.cs
@@ -289,22 +289,10 @@ namespace Rebus.AdoNet
 			return string.Empty;
 		}
 
-		private bool ShouldIndexValue(object value)
-		{
-			if (IndexNullProperties)
-				return true;
-
-			if (value == null) return false;
-			if (value is string) return true;
-			if ((value is IEnumerable) && !(value as IEnumerable).Cast<object>().Any()) return false;
-
-			return true;
-		}
-
 		private IDictionary<string, object> GetCorrelationItems(ISagaData sagaData, IEnumerable<string> sagaDataPropertyPathsToIndex)
 		{
 			return sagaDataPropertyPathsToIndex
-				   .Select(x => new { Key = x, Value = Reflect.Value(sagaData, x) })
+				   .ToDictionary(x => x, x => Reflect.Value(sagaData, x))
 				   .Where(ShouldIndexValue)
 				   .ToDictionary(x => x.Key, x => x.Value);
 		}

--- a/Rebus.AdoNet/AdoNetSagaPersisterLegacy.cs
+++ b/Rebus.AdoNet/AdoNetSagaPersisterLegacy.cs
@@ -705,22 +705,10 @@ namespace Rebus.AdoNet
 			return UseSqlArrays && dialect.SupportsArrayTypes;
 		}
 
-		private bool ShouldIndexValue(object value)
-		{
-			if (IndexNullProperties)
-				return true;
-
-			if (value == null) return false;
-			if (value is string) return true;
-			if ((value is IEnumerable) && !(value as IEnumerable).Cast<object>().Any()) return false;
-
-			return true;
-		}
-
 		private IDictionary<string, object> GetPropertiesToIndex(ISagaData sagaData, IEnumerable<string> sagaDataPropertyPathsToIndex)
 		{
 			return sagaDataPropertyPathsToIndex
-				.Select(x => new { Key = x, Value = Reflect.Value(sagaData, x) })
+				.ToDictionary(x => x, x => Reflect.Value(sagaData, x))
 				.Where(ShouldIndexValue)
 				.ToDictionary(x => x.Key, x => x.Value);
 		}


### PR DESCRIPTION
Additionally, I've added two excludes more..
- Guids: No sense to correlate it if has def value.
- DateTime: May strange to correlate w/ a date, but

Added a test checking that some data properties w/ null or def value are not indexed.. so we should not be able to correlate them later.