### PR TITLE
Some reflected properties in PostgreSqlExceptionAdapter may not exist

### DIFF
--- a/Rebus.AdoNet.Tests/Rebus.AdoNet.Tests.csproj
+++ b/Rebus.AdoNet.Tests/Rebus.AdoNet.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -106,7 +106,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.102.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.102.0\build\net45\System.Data.SQLite.Core.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Rebus.AdoNet.Tests/packages.config
+++ b/Rebus.AdoNet.Tests/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Npgsql" version="3.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.13.3" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="4.2.1" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="4.3.2" targetFramework="net45" />
   <package id="Rebus" version="0.84.0" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.102.0" targetFramework="net45" />

--- a/Rebus.AdoNet/Dialects/PostgreSqlExceptionAdapter.cs
+++ b/Rebus.AdoNet/Dialects/PostgreSqlExceptionAdapter.cs
@@ -23,8 +23,8 @@ namespace Rebus.AdoNet.Dialects
 		public override string Message => _exception.Message;
 		public override string StackTrace => _exception.StackTrace;
 
-		public string Code => GetPropertyValue<string>("Code", _exception);
-		public string ErrorSql => GetPropertyValue<string>("ErrorSql", _exception);
+		public string Code => TryGetPropertyValue<string>("Code", _exception);
+		public string ErrorSql => TryGetPropertyValue<string>("ErrorSql", _exception);
 
 		public override string HelpLink
 		{
@@ -57,10 +57,10 @@ namespace Rebus.AdoNet.Dialects
 			_exception = exception.ThrowIfNull(nameof(exception));
 		}
 
-		public static T GetPropertyValue<T>(string propertyName, object instance)
+		public static T TryGetPropertyValue<T>(string propertyName, object instance)
 		{
 			var bflags = BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-			return (T)instance.GetType().GetProperty(propertyName, bflags).GetValue(instance, null);
+			return (T)instance.GetType().GetProperty(propertyName, bflags)?.GetValue(instance, null);
 		}
 
 		#region DbException overriden methods..


### PR DESCRIPTION
```csharp
using (var connection = Factory.CreateConnection())
{
    connection.ConnectionString = ConnectionString;
    connection.Open();

    // iptables -A OUTPUT -p tcp --sport 5432 -j DROP

    connection.ExecuteCommand("SELECT 1;"); //< STUCK, EX
}
```

This code has two different throwing exceptions depending on underlying Npgsql adapter.

- In v3.0.3, the given exception in this repro isn't a NpgsqlException.
  - NpgsqlException was sealed.
  - NpgsqlException contains properties like 'Code' (that we were reflecting).
- In v4.0.4, the given exception is a NpgsqlException (inner -> IOException -> inner -> SocketException)
  - NpgsqlException is not sealed anymore.
    - All the properties except 'IsTransient' were removed from this layer.
    - PostgresException (new) extends now NpsqlException and contains 'Code'.

As this project does not reference/pin any Npgsql version, we should 'Try' to get reflected property if exists (and depending on the current Npgsql version, we cannot check by class name if proceed or not)

Regards
